### PR TITLE
Repair slack format

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -29,7 +29,13 @@ class NotificationServices::SlackService < NotificationService
     recent = problem.notices.where(:created_at.gte => 5.minutes.ago).count
     message = problem.message.gsub(/\s+/," ").truncate(100)
     app = problem.app.name
-    "#{app} - total:#{problem.notices_count}  5min:#{recent}"
+    "#{app} - total:#{problem.notices_count}  5min:#{recent} <#{problem.url}|#{encode(message)}>"
+  end
+
+  def encode(str)
+    str.gsub("&", "&amp;")
+    .gsub("<", "&lt;")
+    .gsub(">", "&gt;")
   end
 
   def post_payload(problem)
@@ -37,14 +43,7 @@ class NotificationServices::SlackService < NotificationService
       username:    "Errbit",
       icon_url:    "https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png",
       channel:     room_id,
-      attachments: [
-        {
-          title:      problem.message.to_s.truncate(100),
-          title_link: problem.url,
-          text:       message_for_slack(problem),
-          color:      "#D00000",
-        }
-      ]
+      text:        message_for_slack(problem),
     }.compact.to_json # compact to remove empty channel in case it wasn't selected by user
   end
 


### PR DESCRIPTION
With a little bit of tweaking!

See this merge:
https://github.com/errbit/errbit/commit/065d72a856342cd7ee14928bb2a496fe8ca9c1bf
for the source for this change.

The default errbit slack messages are really verbose visually take up a
lot of space in the channel. Simplify it down.

A nice little tweak here is setting the username and icon to the default
from upstream!

---

Please feel free to critique the format here!

For reference:
- The new errbit default slack message format:
![image](https://user-images.githubusercontent.com/6876047/47674021-8e4e0580-db73-11e8-8c31-384b623ce9e9.png)
- Our new format (this pull!):
![image](https://user-images.githubusercontent.com/6876047/47674055-a0c83f00-db73-11e8-8ef4-2fb18c04989b.png)
- The old format:
![image](https://user-images.githubusercontent.com/6876047/47674094-bb9ab380-db73-11e8-80fe-3839a7c9ca9c.png)


I think this one was a viable intermediate, (revert the second commit to get this):
![image](https://user-images.githubusercontent.com/6876047/47674145-dcfb9f80-db73-11e8-84b1-ede2a63c0b28.png)
But it could be visually distracting if we get a bunch in a row. /shrug.

Thoughts, concerns, opinions welcome!

---

qa_req 0 (it's live!)

CC @danielbeardsley @evannoronha 