### PR TITLE
Errbit: Set bigdecimal gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'actionpack', RAILS_VERSION
 gem 'railties', RAILS_VERSION
 
 gem 'actionmailer_inline_css'
+gem 'bigdecimal', '~> 1.4'
 gem 'decent_exposure'
 gem 'devise', '~> 4.7'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    bigdecimal (1.4.4)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     bson (4.8.2)
@@ -425,6 +426,7 @@ DEPENDENCIES
   actionpack (~> 4.2.10)
   airbrake (~> 4.3.5)
   better_errors
+  bigdecimal (~> 1.4)
   binding_of_caller
   campy
   capybara
@@ -486,4 +488,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.1.2
+   2.1.4


### PR DESCRIPTION
The stats role isn't booting on Fedora 32 (which includes a more recent version of ruby, 2.7). After some googling, it turns out we need to pick a version of the bigdecimal gem that is compatible with errbit.

See: https://github.com/ruby/bigdecimal#which-version-should-you-select

I've tested this out, and it get us past asset compilation stage that was failing.

qa_req 0

Ref: https://github.com/iFixit/server-templates/issues/2748

CC @danielbeardsley @addison-grant @iFixit/devops 